### PR TITLE
Added support Docker for easy way to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:7.3-apache
+
+# Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Create working and temp directory
+RUN cd /var/www && mkdir var/ && chmod -R 0777 var/
+RUN mkdir /app
+
+# Copy code-base
+COPY example/ /var/www/html
+COPY vendor/ /var/www/vendor
+COPY src/ /var/www/src
+
+# Copy dummy data for trying
+COPY example/dag.neon /app/dag.neon
+
+# Make symlink
+RUN ln -sf /app/dag.neon
+
+WORKDIR /app
+
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  dag:
+    image: jakubenglicky/ninjify-dag:latest
+    volumes:
+      - ./example/dag.neon:/app/dag.neon
+    environment:
+      DEBUG: 1
+    ports:
+      - 5555:80

--- a/example/.htaccess
+++ b/example/.htaccess
@@ -1,0 +1,9 @@
+<IfModule mod_rewrite.c>
+
+   RewriteEngine On
+
+   RewriteCond %{REQUEST_FILENAME}  -f [OR]
+   RewriteCond %{REQUEST_FILENAME} !-f
+   RewriteRule ^(.*)$ index.php [L,QSA]
+
+</IfModule>

--- a/example/dag.neon
+++ b/example/dag.neon
@@ -1,0 +1,53 @@
+dag:
+    endpoints:
+        /api/:
+            generator: alice
+            data:
+                schema:
+                    stdClass:
+                        api:
+                            name: Acme API
+                            version: "1.0"
+                            time: "<(time())>"
+
+        /api/v1/users:
+            generator: alice
+            data:
+                schema:
+                    stdClass:
+                        "user{1..10}":
+                            name: "<firstName()>"
+                            surname: "<lastName()>"
+                            email: "<email()>"
+                            role: "<jobTitle()>"
+                            createdAt: "<date_create()>"
+                            lastLoggedAt: "<date_create()>"
+
+        /api/v1/groups:
+            generator: alice
+            data:
+                schema:
+                    stdClass:
+                        "groups{1..10}":
+                            name: "<firstName()>"
+
+        /api/v1/pricing:
+            generator: alice
+            data:
+                normalize: "@@tariff{1..3}"
+                schema:
+                    stdClass:
+                        "tariff_bare (template)":
+                            name: "<firstName()>"
+                            price: "<randomNumber(3)>"
+                            description: "<catchPhrase()>"
+                            "features (unique)": "<numberBetween(2,5)>x @feature*"
+                            size: 3
+
+                        "tariff{1..3} (extends tariff_bare)":
+                        "tariff{2} (extends tariff_bare)":
+                            size: 5
+
+                        "feature{1..15}":
+                            "name (unique)": '<word()>'
+                            stars: '<randomDigit()>'

--- a/example/index.php
+++ b/example/index.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types = 1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+\Dag\Grub::boot();


### PR DESCRIPTION
Hi f3l1x,
you can try use dag with Docker and dummy data.

Only use this command `docker run -p 5555:80 -d jakubenglicky/ninjify-dag:latest`, visit http://localhost:5555/api/ and that's all.

Before merge this PR, my docker image change to an official ninjify organization.

It's possible for you?